### PR TITLE
CLI Configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <dependency>
       <groupId>org.hawkular.commons</groupId>
       <artifactId>hawkular-commons-embedded-cassandra-ear</artifactId>
-      <version>0.2.2.Final-SNAPSHOT</version>
+      <version>0.2.3.Final-SNAPSHOT</version>
       <type>ear</type>
       <scope>test</scope>
     </dependency>

--- a/src/main/generated/io/vertx/ext/hawkular/VertxHawkularOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/hawkular/VertxHawkularOptionsConverter.java
@@ -17,6 +17,7 @@
 package io.vertx.ext.hawkular;
 
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
 
 /**
  * Converter for {@link io.vertx.ext.hawkular.VertxHawkularOptions}.

--- a/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
+++ b/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
@@ -243,12 +243,7 @@ public class VertxHawkularOptions extends MetricsOptions {
   }
 
   @Override
-  public boolean isEnabled() {
-    return super.isEnabled();
-  }
-
-  @Override
-  public MetricsOptions setEnabled(boolean enable) {
+  public VertxHawkularOptions setEnabled(boolean enable) {
     super.setEnabled(enable);
     return this;
   }

--- a/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
+++ b/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
@@ -241,4 +241,15 @@ public class VertxHawkularOptions extends MetricsOptions {
     this.batchDelay = batchDelay;
     return this;
   }
+
+  @Override
+  public boolean isEnabled() {
+    return super.isEnabled();
+  }
+
+  @Override
+  public MetricsOptions setEnabled(boolean enable) {
+    super.setEnabled(enable);
+    return this;
+  }
 }

--- a/src/main/java/io/vertx/ext/hawkular/impl/VertxMetricsFactoryImpl.java
+++ b/src/main/java/io/vertx/ext/hawkular/impl/VertxMetricsFactoryImpl.java
@@ -37,4 +37,9 @@ public class VertxMetricsFactoryImpl implements VertxMetricsFactory {
     }
     return new VertxMetricsImpl(vertx, vertxHawkularOptions);
   }
+
+  @Override
+  public MetricsOptions newOptions() {
+    return new VertxHawkularOptions();
+  }
 }


### PR DESCRIPTION
Allow CLI configuration such as:

```
-Dvertx.metrics.options.enabled=true -Dvertx.metrics.options.host=192.168.99.100 -Dvertx.metrics.options.port=8090 -Dvertx.metrics.options.tenant=default -Dvertx.metrcs.options.prefix=hk-bridge -Dvertx.metrics.options.batchDelay=10
```
